### PR TITLE
[STAB-17] Fix unsync local client to invoke callback

### DIFF
--- a/abci/client/unsync_local_client.go
+++ b/abci/client/unsync_local_client.go
@@ -262,6 +262,7 @@ func (app *unsyncLocalClient) ProcessProposalSync(req types.RequestProcessPropos
 func (app *unsyncLocalClient) callback(req *types.Request, res *types.Response) *ReqRes {
 	app.mtx.RLock()
 	defer app.mtx.RUnlock()
+	app.Callback(req, res)
 	rr := newLocalReqRes(req, res)
 	rr.callbackInvoked = true
 	return rr


### PR DESCRIPTION
This was missed in https://github.com/dydxprotocol/cometbft/commit/4a837ddd72fbc5866409501e307de73c0592d8f1 and caused the chain to fail to initialize.