### PR TITLE
Proof-of-Concept: Add prevote check for ValidBlock

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1285,10 +1285,10 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		return
 	}
 
-	// If it is known that this block is valid, prevote it
-	// ProposalBlock already has a nil check above
-	if cs.ValidBlock != nil && bytes.Equal(cs.ValidBlock.Hash(), cs.ProposalBlock.Hash()) {
-		logger.Debug("prevote step: ProposalBlock is equal to ValidBlock")
+	// If it is known that the proposed block is valid, prevote it.
+	// ProposalBlock is non-nil given the check above.
+	if cs.ValidBlock.HashesTo(cs.ProposalBlock.Hash()) {
+		logger.Debug("prevote step: ProposalBlock is equal to ValidBlock; prevoting block")
 		cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
 		return
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1285,6 +1285,15 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		return
 	}
 
+	// Check if it is known that this block is valid
+	// ProposalBlock already has a nil check above
+	if cs.ValidBlock != nil && bytes.Equal(cs.ValidBlock.Hash(), cs.ProposalBlock.Hash()) {
+		// ProposalBlock is valid, prevote it.
+		logger.Debug("prevote step: ProposalBlock is equal to ValidBlock")
+		cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
+		return
+	}
+
 	// Validate proposal block, from consensus' perspective
 	err := cs.blockExec.ValidateBlock(cs.state, cs.ProposalBlock)
 	if err != nil {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1285,10 +1285,9 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		return
 	}
 
-	// Check if it is known that this block is valid
+	// If it is known that this block is valid, prevote it
 	// ProposalBlock already has a nil check above
 	if cs.ValidBlock != nil && bytes.Equal(cs.ValidBlock.Hash(), cs.ProposalBlock.Hash()) {
-		// ProposalBlock is valid, prevote it.
 		logger.Debug("prevote step: ProposalBlock is equal to ValidBlock")
 		cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
 		return


### PR DESCRIPTION
Add a check to see if the proposed block matches the known `ValidBlock`. If so, prevote for the block.

Notably, this change will skip calls to the following checks if-and-only-if the block is equal to the `ValidBlock`, thereby introducing a logic change:
- `cs.blockExec.ValidateBlock(...)`
- `cs.blockExec.ProcessProposal(...)`

In order to reduce any major consensus changes, this check will run after other consensus-defining rules such as the `LockedBlock` check. However, it should be noted that this check is likely a bug, see https://github.com/tendermint/tendermint/issues/6850

This PR is missing tests