### PR TITLE
[CORE-435] Prevote yes on recent valid POL Proposal

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1271,7 +1271,7 @@ func (cs *State) enterPrevote(height int64, round int32) {
 func (cs *State) defaultDoPrevote(height int64, round int32) {
 	logger := cs.Logger.With("height", height, "round", round)
 
-	// If a block is locked, prevote that.
+	// If a block is locked, prevote that. TODO(CORE-434): Incorporate fix from Proposer-based Timestamp.
 	if cs.LockedBlock != nil {
 		logger.Debug("prevote step; already locked on a block; prevoting locked block")
 		cs.signAddVote(cmtproto.PrevoteType, cs.LockedBlock.Hash(), cs.LockedBlockParts.Header())
@@ -1295,26 +1295,46 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		return
 	}
 
+	/// The following implements line 28 - 33 of algorithm:
+	//
+	// 	upon ⟨PROPOSAL, h_p, round_p, v, vr⟩ from proposer(h_p, round_p)
+	// 	AND 2f + 1 ⟨PREVOTE, h_p, vr, id(v)⟩
+	// 	while step_p = propose ∧ (vr ≥ 0 ∧ vr < round_p) do {
+	// 	  if valid(v) ∧ (lockedRound_p ≤ vr ∨ lockedValue_p = v) {
+	// 		  broadcast ⟨PREVOTE, h_p, round_p, id(v)⟩
+	// 	  } else {
+	// 		  broadcast ⟨PREVOTE, h_p, round_p, nil⟩
+	// 	  }
+	// 	  step_p ← prevote
+	//  }
+	//
 	// Determine if the proposed block has a sane, non-nil proof-of-lock.
 	if cs.Proposal.POLRound >= 0 && cs.Proposal.POLRound < cs.Round {
 		// Validate the proof-of-lock using known prevotes.
 		blockID, ok := cs.Votes.Prevotes(cs.Proposal.POLRound).TwoThirdsMajority()
 		if ok && cs.ProposalBlock.HashesTo(blockID.Hash) {
 			// Validate the proof-of-lock round is at least as new as the possible locked round.
+			// (vr >= 0, vr > round_p, 2f+1 prevotes at round vr, lockedRound_p <= vr) execute 30.
 			if cs.Proposal.POLRound >= cs.LockedRound {
 				logger.Debug("prevote step: ProposalBlock POLRound >= LockedRound; prevoting the block")
 				cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
 				return
 			}
 
+			// TODO(CORE-434): The following implements the canonical Tendermint algorithm, but the condition
+			// is never true due to locked block logic (line 1275) above, a known bug in current implementation.
+			// Uncomment the following when locked block logic is fixed.
+			//
 			// Validate the proposed block is equal to our locked block.
-			if cs.ProposalBlock.HashesTo(cs.LockedBlock.Hash()) {
-				logger.Debug("prevote step: ProposalBlock matches our locked block; prevoting the block")
-				cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
-				return
-			}
+			// (vr >= 0, vr > round_p, 2f+1 prevotes at round vr, lockedRound_p <= vr) execute 30.
+			// if cs.ProposalBlock.HashesTo(cs.LockedBlock.Hash()) {
+			// 	logger.Debug("prevote step: ProposalBlock matches our locked block; prevoting the block")
+			// 	cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
+			// 	return
+			// }
 
 			// Proof-of-lock is before our locked round.
+			// (else case on line 31) execute line 32.
 			logger.Debug("prevote step: ProposalBlock POLRound < LockedRound; prevoting nil")
 			cs.signAddVote(cmtproto.PrevoteType, nil, types.PartSetHeader{})
 			return

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1271,7 +1271,8 @@ func (cs *State) enterPrevote(height int64, round int32) {
 func (cs *State) defaultDoPrevote(height int64, round int32) {
 	logger := cs.Logger.With("height", height, "round", round)
 
-	// If a block is locked, prevote that. TODO(CORE-434): Incorporate fix from Proposer-based Timestamp.
+	// If a block is locked, prevote that.
+	// TODO(CORE-434): Incorporate fix from Proposer-based Timestamp.
 	if cs.LockedBlock != nil {
 		logger.Debug("prevote step; already locked on a block; prevoting locked block")
 		cs.signAddVote(cmtproto.PrevoteType, cs.LockedBlock.Hash(), cs.LockedBlockParts.Header())
@@ -1315,6 +1316,8 @@ func (cs *State) defaultDoPrevote(height int64, round int32) {
 		if ok && cs.ProposalBlock.HashesTo(blockID.Hash) {
 			// Validate the proof-of-lock round is at least as new as the possible locked round.
 			// (vr >= 0, vr > round_p, 2f+1 prevotes at round vr, lockedRound_p <= vr) execute 30.
+			// Note we skipped the `valid(v)`` check, since at POLRound we've witnessed 2/3+ prevotes for `v`.
+			// This means 1/3+ honest validators have accepted the block.
 			if cs.Proposal.POLRound >= cs.LockedRound {
 				logger.Debug("prevote step: ProposalBlock POLRound >= LockedRound; prevoting the block")
 				cs.signAddVote(cmtproto.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())


### PR DESCRIPTION
## Description
If a proposal with a proof-of-lock (POL) is proposed, validate both of the following two lines:
- That this validator has seen +2/3 prevotes for this block in the given POL Round (Line 28 of whitepaper algorithm)
- That `Proposed Block = Locked Block` OR `POL Round >= Locked Round` (Line 29 of whitepaper algorithm)

If these two things both evaluate to `true`, then prevote the block without consulting the Application (i.e. without calling `ProcessProposal`) to determine the validity of the block.

If either of these two checks evaluate to `false`, then prevote nil. Even if the block is valid, we don't prevote for the block. (Line 29/31 of whitepaper algorithm)

This change is aimed at fixing the liveness issue experienced in public testnet 1.

## Implementation
Unfortunately it looks more complicated than necessary primarily because we need the `Debug` statements to say different things in different cases, so there are two places to prevote the block and two places to prevote nil (rather than just having one each).

## Justification
It should be fine to not consult the Application to validate the block in the above case. To show this, let us first state that `ProcessProposal` may have both deterministic and non-deterministic validation.
- In order to proceed with consensus, we choose to ignore any non-deterministic checks. This is the same logic as in the PBTS implementation (i.e. ignore the timely check for POL proposals).
- For deterministic checks, we know that at least one honest validator has validated the block. This is because we validate that +2/3 of validators have prevoted the block in a previous round. On the lowest round this is true for the block (assuming that we do not have +2/3 Byzantine validators) `ProcessProposal` (and therefore its deterministic checks) MUST have passed at least one honest validator. Therefore, there no need to run the deterministic checks locally.

## References
Based on some logic added for the PBTS [here](https://github.com/tendermint/tendermint/blob/73b22c03b4953c9a3cc2b3f8c20f93136f3e3bcd/internal/consensus/state.go#L1477-L1507)

This logic is also largely the same as lines 28-32 on page 6 of the [Tendermint whitepaper](https://arxiv.org/pdf/1807.04938.pdf), however we do not validate the block with the Application (i.e. `ProcessProposal`) to determine `valid(v)`. As I have justified above, this check to `valid(v)` is unnecessary assuming <2/3 Byzantine validators.