### PR TITLE
Cherrypicks: Add check for non-nil in enterCommit + Log proposer's address when accepting a proposal

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -237,7 +237,7 @@ func (blockExec *BlockExecutor) ApplyBlock(
 		return state, 0, err
 	}
 	if len(validatorUpdates) > 0 {
-		blockExec.logger.Debug("updates to validators", "updates", types.ValidatorListString(validatorUpdates))
+		blockExec.logger.Info("updates to validators", "updates", types.ValidatorListString(validatorUpdates))
 		blockExec.metrics.ValidatorSetUpdates.Add(1)
 	}
 	if abciResponses.EndBlock.ConsensusParamUpdates != nil {


### PR DESCRIPTION
Port over two changes from `cometbft/cometbft` main in `state.go`:

https://github.com/cometbft/cometbft/pull/1208: Add check for non-nil in enterCommit 
https://github.com/cometbft/cometbft/pull/1079: Log proposer's address when correctly accepting a proposal