### PR TITLE
[CT-512] exclude MsgBatchCancel from mempool

### DIFF
--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -754,7 +754,7 @@ func TestMempoolConcurrentUpdateAndReceiveCheckTxResponse(t *testing.T) {
 		go func(h int) {
 			defer wg.Done()
 
-			err := mp.Update(int64(h), []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+			err := mp.Update(int64(h), time.UnixMilli(1), []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 			require.NoError(t, err)
 			require.Equal(t, int64(h), mp.height.Load(), "height mismatch")
 		}(h)
@@ -798,7 +798,7 @@ func TestMempoolNotifyTxsAvailable(t *testing.T) {
 	require.Empty(t, mp.TxsAvailable())
 
 	// Updating the pool will remove the tx and set the variable to false
-	err := mp.Update(1, []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
+	err := mp.Update(1, time.UnixMilli(1), []types.Tx{tx}, abciResponses(1, abci.CodeTypeOK), nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, mp.Size())
 	require.False(t, mp.notifiedTxsAvailable.Load())

--- a/mempool/dydx_helpers.go
+++ b/mempool/dydx_helpers.go
@@ -9,7 +9,7 @@ import (
 
 // IsShortTermClobOrderTransaction returns true if the provided `tx` is a
 // Cosmos transaction containing a short-term `MsgPlaceOrder` or
-// short-term `MsgCancelOrder` message.
+// short-term `MsgCancelOrder` or `MsgBatchCancel` message.
 func IsShortTermClobOrderTransaction(
 	tx types.Tx,
 	mempoolLogger log.Logger,
@@ -43,6 +43,10 @@ func IsShortTermClobOrderTransaction(
 				panic("Failed to unmarshal MsgCancelOrder from Cosmos transaction.")
 			}
 			return msgCancelOrder.OrderId.IsShortTermOrder()
+		}
+		if cosmosTx.Body.Messages[0].TypeUrl == "/dydxprotocol.clob.MsgBatchCancel" {
+			// MsgBatchCancel only processes short term order cancellations as of right now.
+			return true
 		}
 	}
 


### PR DESCRIPTION
Exclude new `MsgBatchCancel` from mempool.

Also fixes some lint errors in test files unrelated to this pr.