### PR TITLE
Add an software override (1sec) for `TimeoutPropose`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ const (
 
 	MempoolTypeFlood = "flood"
 	MempoolTypeNop   = "nop"
+
+	TimeoutProposeOverride = 1 * time.Second
 )
 
 // NOTE: Most of the structs & relevant comments + the
@@ -981,6 +983,7 @@ type ConsensusConfig struct {
 	walFile string // overrides WalPath if set
 
 	// How long we wait for a proposal block before prevoting nil
+	// Deprecated: a software default of 1 second is used instead.
 	TimeoutPropose time.Duration `mapstructure:"timeout_propose"`
 	// How much timeout_propose increases with each round
 	TimeoutProposeDelta time.Duration `mapstructure:"timeout_propose_delta"`
@@ -1058,7 +1061,9 @@ func (cfg *ConsensusConfig) WaitForTxs() bool {
 // Propose returns the amount of time to wait for a proposal
 func (cfg *ConsensusConfig) Propose(round int32) time.Duration {
 	return time.Duration(
-		cfg.TimeoutPropose.Nanoseconds()+cfg.TimeoutProposeDelta.Nanoseconds()*int64(round),
+		// Provide an override for `timeout_propose`. This value should be consistent across the network
+		// for synchrony, and should never be tweaked by individual validators in practice.
+		TimeoutProposeOverride.Nanoseconds()+cfg.TimeoutProposeDelta.Nanoseconds()*int64(round),
 	) * time.Nanosecond
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -461,6 +461,7 @@ version = "{{ .BlockSync.Version }}"
 wal_file = "{{ js .Consensus.WalPath }}"
 
 # How long we wait for a proposal block before prevoting nil
+# Deprecated: a software default of 1 second is used instead.
 timeout_propose = "{{ .Consensus.TimeoutPropose }}"
 # How much timeout_propose increases with each round
 timeout_propose_delta = "{{ .Consensus.TimeoutProposeDelta }}"


### PR DESCRIPTION
# Problem

Network experiences a `~5sec` block time when a proposer is offline/severely lagging behind. This is due to the current software default, `TimeoutPropose = 3s`, which means that when a proposer is unavailable, we spend 3s waiting for the proposal + 0.5s for round 0 prevote/precommit, so `~3.5s` more than an average block. 

This software default of `3s` was not conscious, and could've been updated along when `timeout_commit` was reduced to `500ms`.

See attached [block dump](https://dydx-team.slack.com/archives/C03FP255RRU/p1718920517021299?thread_ts=1718920455.352289&cid=C03FP255RRU) during a period when 2 small validators went offline, and 4% of the blocks have elevated >5sec blocks. As a result, average block time is much higher than median block time during this period:
```
Median block time: 1.1144995 seconds
Average block time: 1.35415654 seconds
```

# Solution

Add a software override for `TimeoutPropose` to `1s`. This should be more than enough for a [block where proposer is present. ](https://app.datadoghq.com/dashboard/25s-bg4-rfr?fromUser=false&fullscreen_end_ts=1718747340000&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=edit&fullscreen_start_ts=1718740140000&fullscreen_widget=7303499879955068&refresh_mode=paused&tpl_var_env%5B0%5D=mainnet&view=spans&from_ts=1718802091418&to_ts=1718809804409&live=false). This reduces p99 and average block time.

This requires a coordinated upgrade to maintain synchrony among validators.

<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments
