### PR TITLE
select proposers from reduced proposer set

### DIFF
--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -561,9 +561,7 @@ func TestUpdateValidators(t *testing.T) {
 		},
 		{
 			"adding a validator to proposer set is OK",
-			types.NewValidatorSet([]*types.Validator{
-				types.NewValidator(pubkey1, 10, false),
-			}),
+			types.NewValidatorSet([]*types.Validator{}),
 			[]abci.ValidatorUpdate{{PubKey: pk, Power: 10, CanPropose: true}},
 			types.NewValidatorSet([]*types.Validator{
 				types.NewValidator(pubkey1, 10, true),
@@ -572,10 +570,11 @@ func TestUpdateValidators(t *testing.T) {
 		},
 		{
 			"removing a validator from proposer set is OK",
-			types.NewValidatorSet([]*types.Validator{val1}),
+			types.NewValidatorSet([]*types.Validator{val1, val2}),
 			[]abci.ValidatorUpdate{{PubKey: pk, Power: 10, CanPropose: false}},
 			types.NewValidatorSet([]*types.Validator{
 				types.NewValidator(pubkey1, 10, false),
+				val2,
 			}),
 			false,
 		},

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -218,7 +218,14 @@ func computeMaxMinPriorityDiff(vals *ValidatorSet) int64 {
 func (vals *ValidatorSet) getValWithMostPriority() *Validator {
 	var res *Validator
 	for _, val := range vals.Validators {
-		res = res.CompareProposerPriority(val)
+		// Only consider validators that can propose
+		if val.CanPropose {
+			res = res.CompareProposerPriority(val)
+		}
+	}
+	// If no validator can propose, panic as this is an invalid state
+	if res == nil {
+		panic("no validators can propose")
 	}
 	return res
 }
@@ -335,9 +342,14 @@ func (vals *ValidatorSet) GetProposer() (proposer *Validator) {
 func (vals *ValidatorSet) findProposer() *Validator {
 	var proposer *Validator
 	for _, val := range vals.Validators {
-		if proposer == nil || !bytes.Equal(val.Address, proposer.Address) {
+		// Only consider validators that can propose
+		if val.CanPropose && (proposer == nil || !bytes.Equal(val.Address, proposer.Address)) {
 			proposer = proposer.CompareProposerPriority(val)
 		}
+	}
+	// If no validator can propose, panic as this is an invalid state
+	if proposer == nil {
+		panic("no validators can propose")
 	}
 	return proposer
 }
@@ -710,6 +722,10 @@ func (vals *ValidatorSet) VerifyCommitLightTrustingAllSignatures(
 func (vals *ValidatorSet) findPreviousProposer() *Validator {
 	var previousProposer *Validator
 	for _, val := range vals.Validators {
+		// Only consider validators that can propose
+		if !val.CanPropose {
+			continue
+		}
 		if previousProposer == nil {
 			previousProposer = val
 			continue

--- a/types/validator_set_reduced_proposer_set_test.go
+++ b/types/validator_set_reduced_proposer_set_test.go
@@ -1,0 +1,103 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReducedProposerSet(t *testing.T) {
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, true),
+		newValidator([]byte("val2"), 200, false),
+		newValidator([]byte("val3"), 300, true),
+		newValidator([]byte("val4"), 400, false),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Initial proposer should have CanPropose=true
+	assert.True(t, vset.GetProposer().CanPropose)
+
+	// Track proposers over 100 rounds
+	proposers := make(map[string]int)
+	for i := 0; i < 100; i++ {
+		vset.IncrementProposerPriority(1)
+		p := vset.GetProposer()
+		assert.True(t, p.CanPropose)
+		proposers[string(p.Address)]++
+	}
+
+	// Verify that only val1 and val3 are proposers and val3 is selected more
+	// often due to having higher voting power
+	assert.Equal(t, 2, len(proposers))
+	assert.Greater(t, proposers[string([]byte("val3"))], proposers[string([]byte("val1"))])
+}
+
+func TestSingleProposer(t *testing.T) {
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, false),
+		newValidator([]byte("val2"), 200, true), // Only proposer
+		newValidator([]byte("val3"), 300, false),
+	}
+	vset := NewValidatorSet(vals)
+
+	// val2 should always be the proposer
+	for i := 0; i < 10; i++ {
+		vset.IncrementProposerPriority(1)
+		assert.Equal(t, string([]byte("val2")), string(vset.GetProposer().Address))
+	}
+}
+
+func TestNoProposers(t *testing.T) {
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, false),
+		newValidator([]byte("val2"), 200, false),
+	}
+
+	// Panics when no validators can propose
+	assert.Panics(t, func() {
+		NewValidatorSet(vals)
+	})
+}
+
+func TestProposerPriorityIncrementForAll(t *testing.T) {
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, true),
+		newValidator([]byte("val2"), 100, false),
+		newValidator([]byte("val3"), 100, true),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Store initial priorities
+	initial := make([]int64, len(vals))
+	for i, v := range vset.Validators {
+		initial[i] = v.ProposerPriority
+	}
+
+	// Increment 10 times
+	for i := 0; i < 10; i++ {
+		vset.IncrementProposerPriority(1)
+	}
+
+	// Priorities should change for all validators (not just proposers)
+	for i, v := range vset.Validators {
+		assert.NotEqual(t, initial[i], v.ProposerPriority)
+	}
+}
+
+func TestCopyCanPropose(t *testing.T) {
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, true),
+		newValidator([]byte("val2"), 200, false),
+		newValidator([]byte("val3"), 300, true),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Make a copy
+	vsetCopy := vset.Copy()
+
+	// Verify all validators maintain their CanPropose status
+	for i, v := range vset.Validators {
+		assert.Equal(t, v.CanPropose, vsetCopy.Validators[i].CanPropose)
+	}
+}

--- a/types/validator_set_reduced_proposer_set_test.go
+++ b/types/validator_set_reduced_proposer_set_test.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,4 +102,164 @@ func TestCopyCanPropose(t *testing.T) {
 	for i, v := range vset.Validators {
 		assert.Equal(t, v.CanPropose, vsetCopy.Validators[i].CanPropose)
 	}
+}
+
+// As all validators accumulate proposer priority but only proposers get their priority deducted,
+// those who aren't part of the proposer set will have accumulated priority that's much higher than
+// those who are in the proposer set and can impact proposer selection once they join the proposer set.
+//
+// Below tests demonstrate that the system quickly resolves this imbalance and behaves as normal.
+// Note: can be run with verbose logging to see how priorities change each round.
+//
+// Mathematically, the max diff of priorities in a proposer set is bounded to 2 * TotalVotingPower
+// and a proposer's priority is reduced by TotalVotingPower each time it's selected. Thus, a newly joined
+// proposer can be selected at most 2 times in a row before its priority falls below those who have been
+// part of the proposer set. TestAddOneToProposerSet and TestAddManyToProposerSet programmatically verify
+// such behavior.
+func TestAddOneToProposerSet(t *testing.T) {
+	// Set up
+	// - proposer set: val1
+	// - additional validator: val2
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, true),
+		newValidator([]byte("val2"), 100, false),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Let proposer selection run for some rounds
+	incrementAndLogProposerPriority(vset, 50, "Before adding val2 to proposer set")
+
+	// Add val2 to proposer set
+	findValidator(vset, []byte("val2")).CanPropose = true
+
+	// Future proposer selection should be [val2, val2, val1, val2, val1, ...]
+	proposerSequence := incrementAndLogProposerPriority(vset, 100, "\nAfter adding val2 to proposer set")
+
+	assert.Equal(t, "val2", proposerSequence[0])
+	assert.Equal(t, "val2", proposerSequence[1])
+
+	for i := 2; i < len(proposerSequence); i++ {
+		current := proposerSequence[i]
+		prev := proposerSequence[i-1]
+		assert.NotEqual(t, current, prev)
+	}
+}
+
+// Can be run with verbose logging to see how priorities change for different validators.
+func TestAddManyToProposerSet(t *testing.T) {
+	// Set up
+	// - proposer set: val1
+	// - additional validators: val2, val3, val4
+	vals := []*Validator{
+		newValidator([]byte("val1"), 100, true),
+		newValidator([]byte("val2"), 100, false),
+		newValidator([]byte("val3"), 100, false),
+		newValidator([]byte("val4"), 100, false),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Let proposer selection run for some rounds
+	incrementAndLogProposerPriority(vset, 50, "Before adding val2, val3, val4 to proposer set")
+
+	// Add val2, val3, val4 to proposer set
+	findValidator(vset, []byte("val2")).CanPropose = true
+	findValidator(vset, []byte("val3")).CanPropose = true
+	findValidator(vset, []byte("val4")).CanPropose = true
+
+	// Afterwards,
+	// 1. First 6 selections should be round robin among val2, val3, val4
+	// 2. Then system is back to normal and rotates among all 4 proposers
+	// i.e. [val2, val3, val4, val2, val3, val4, val1, val2, val3, val4, ...]
+	proposerSequence := incrementAndLogProposerPriority(vset, 100, "\nAfter adding val2, val3, val4 to proposer set")
+
+	// Verify first 6 proposers
+	firstSix := make(map[string]int)
+	for i := 0; i < 6; i++ {
+		firstSix[proposerSequence[i]]++
+	}
+
+	for _, val := range []string{"val2", "val3", "val4"} {
+		assert.Equal(t, 2, firstSix[val], "%s should appear exactly twice in first 6", val)
+	}
+
+	// Verify subsequent proposers
+	for i := 6; i < len(proposerSequence); i++ {
+		switch i % 4 {
+		case 2:
+			assert.Equal(t, "val1", proposerSequence[i])
+		case 3:
+			assert.Equal(t, "val2", proposerSequence[i])
+		case 0:
+			assert.Equal(t, "val3", proposerSequence[i])
+		case 1:
+			assert.Equal(t, "val4", proposerSequence[i])
+		}
+	}
+}
+
+// Note that this test has no assertions and is mainly for manual inspection of how priorities
+// change for a proposer set where voting powers are vastly different.
+func TestAddManyToProposerSetDifferentPowers(t *testing.T) {
+	// Set up
+	// - proposer set: val2, val3
+	// - additional validators: val1, val4
+	vals := []*Validator{
+		newValidator([]byte("val1"), 50, false),
+		newValidator([]byte("val2"), 500, true),
+		newValidator([]byte("val3"), 5000, true),
+		newValidator([]byte("val4"), 50000, false),
+	}
+	vset := NewValidatorSet(vals)
+
+	// Let proposer selection run for some rounds
+	incrementAndLogProposerPriority(vset, 50, "Before adding val1, val4 to proposer set")
+
+	// Add val1, val4 to proposer set
+	findValidator(vset, []byte("val1")).CanPropose = true
+	findValidator(vset, []byte("val4")).CanPropose = true
+
+	// Run for some rounds
+	incrementAndLogProposerPriority(vset, 50, "\nAfter adding val1, val4 to proposer set")
+}
+
+// findValidator finds a validator by address given a validator set
+func findValidator(vset *ValidatorSet, address []byte) *Validator {
+	for _, v := range vset.Validators {
+		if string(v.Address) == string(address) {
+			return v
+		}
+	}
+	return nil
+}
+
+// incrementAndLogProposerPriority is a helper function that increments proposer priority and logs validator set state.
+// Returns an array of selected proposers by their address strings.
+func incrementAndLogProposerPriority(vset *ValidatorSet, rounds int, phase string) []string {
+	// Build header
+	header := "Round | Selected"
+	divider := "------|----------"
+	for _, v := range vset.Validators {
+		header += fmt.Sprintf(" | %s(%d,%s)", string(v.Address), v.VotingPower,
+			map[bool]string{true: "T", false: "F"}[v.CanPropose])
+		divider += "|" + strings.Repeat("-", 13)
+	}
+
+	fmt.Printf("%s:\n", phase)
+	fmt.Printf("%s\n", header)
+	fmt.Printf("%s\n", divider)
+
+	proposerSequence := []string{}
+	for round := 1; round <= rounds; round++ {
+		vset.IncrementProposerPriority(1)
+		proposer := vset.GetProposer()
+		proposerSequence = append(proposerSequence, string(proposer.Address))
+
+		row := fmt.Sprintf("%5d | %8s", round, string(proposer.Address))
+		for _, v := range vset.Validators {
+			row += fmt.Sprintf(" | %*d", 11, v.ProposerPriority)
+		}
+		fmt.Printf("%s\n", row)
+	}
+
+	return proposerSequence
 }

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -485,9 +485,9 @@ func TestAveragingInIncrementProposerPriority(t *testing.T) {
 		0: {
 			ValidatorSet{
 				Validators: []*Validator{
-					{Address: []byte("a"), ProposerPriority: 1},
-					{Address: []byte("b"), ProposerPriority: 2},
-					{Address: []byte("c"), ProposerPriority: 3},
+					{Address: []byte("a"), ProposerPriority: 1, CanPropose: true},
+					{Address: []byte("b"), ProposerPriority: 2, CanPropose: true},
+					{Address: []byte("c"), ProposerPriority: 3, CanPropose: true},
 				},
 			},
 			1, 2,
@@ -495,9 +495,9 @@ func TestAveragingInIncrementProposerPriority(t *testing.T) {
 		1: {
 			ValidatorSet{
 				Validators: []*Validator{
-					{Address: []byte("a"), ProposerPriority: 10},
-					{Address: []byte("b"), ProposerPriority: -10},
-					{Address: []byte("c"), ProposerPriority: 1},
+					{Address: []byte("a"), ProposerPriority: 10, CanPropose: true},
+					{Address: []byte("b"), ProposerPriority: -10, CanPropose: true},
+					{Address: []byte("c"), ProposerPriority: 1, CanPropose: true},
 				},
 			},
 			// this should average twice but the average should be 0 after the first iteration
@@ -508,9 +508,9 @@ func TestAveragingInIncrementProposerPriority(t *testing.T) {
 		2: {
 			ValidatorSet{
 				Validators: []*Validator{
-					{Address: []byte("a"), ProposerPriority: 100},
-					{Address: []byte("b"), ProposerPriority: -10},
-					{Address: []byte("c"), ProposerPriority: 1},
+					{Address: []byte("a"), ProposerPriority: 100, CanPropose: true},
+					{Address: []byte("b"), ProposerPriority: -10, CanPropose: true},
+					{Address: []byte("c"), ProposerPriority: 1, CanPropose: true},
 				},
 			},
 			1, 91 / 3,
@@ -1580,7 +1580,7 @@ func BenchmarkUpdates(b *testing.B) {
 
 func TestVerifyCommitWithInvalidProposerKey(t *testing.T) {
 	vs := &ValidatorSet{
-		Validators: []*Validator{{}, {}},
+		Validators: []*Validator{{CanPropose: true}, {CanPropose: true}},
 	}
 	commit := &Commit{
 		Height:     100,


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

When selecting block proposers, only consider reduced proposer set, i.e. validators who have `CanPropose=true`

main logic change is in `validator_set.go`

---

#### PR checklist

- [x] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

