### PR TITLE
Backport security patch for GHSA-hrhf-2vcr-ghch

### DIFF
--- a/.changelog/unreleased/bug-fixes/2774-bitarray-unmarshal-json.md
+++ b/.changelog/unreleased/bug-fixes/2774-bitarray-unmarshal-json.md
@@ -1,0 +1,2 @@
+- [`bits`] prevent `BitArray.UnmarshalJSON` from crashing on 0 bits
+  ([\#2774](https://github.com/cometbft/cometbft/pull/2774))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,6 @@
 
 ### BUG-FIXES
 
-- `[consensus]` Reject oversized proposals
-  ([\#5324](https://github.com/cometbft/cometbft/pull/5324))
-- `[store]` Prune extended commits properly
-  ([5275](https://github.com/cometbft/cometbft/issues/5275))
-
 ### STATE-BREAKING
 
 ### API-BREAKING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,390 @@
 # CHANGELOG
 
+## UNRELEASED
+
+### DEPENDENCIES
+
+### BUG FIXES
+
+### IMPROVEMENTS
+
+### FEATURES
+
+### BUG-FIXES
+
+- `[consensus]` Reject oversized proposals
+  ([\#5324](https://github.com/cometbft/cometbft/pull/5324))
+- `[store]` Prune extended commits properly
+  ([5275](https://github.com/cometbft/cometbft/issues/5275))
+
+### STATE-BREAKING
+
+### API-BREAKING
+
+## v0.38.19
+
+*October 14, 2025*
+
+This release fixes two security issues, including ([ASA-2025-003](https://github.com/cometbft/cometbft/security/advisories/GHSA-hrhf-2vcr-ghch)).
+Users are encouraged to upgrade as soon as possible.
+
+Additionally included is a bug fix to properly prune extended commits (with
+vote extensions).
+
+### BUG-FIXES
+
+- `[consensus]` Reject oversized proposals
+  ([\#5324](https://github.com/cometbft/cometbft/pull/5324))
+- `[store]` Prune extended commits properly
+  ([5275](https://github.com/cometbft/cometbft/issues/5275))
+- `[bits]` Validate BitArray mismatched Bits and Elems length
+  ([ASA-2025-003](https://github.com/cometbft/cometbft/security/advisories/GHSA-hrhf-2vcr-ghch))
+
+## v0.38.18
+
+*July 3, 2025*
+
+Adds precommit metrics and reindex CLI command.
+
+### IMPROVEMENTS
+
+- Adds metrics that emit precommit data; precommit quorum delay from proposal, and precommit vote count and stake weight within timeout commit period.
+  ([\#5251](https://github.com/cometbft/cometbft/issues/5251))
+
+## v0.38.17
+
+*February 3, 2025*
+
+This release fixes two security issues (ASA-2025-001, ASA-2025-002). Users are
+encouraged to upgrade as soon as possible.
+
+### BUG FIXES
+
+- `[blocksync]` Ban peer if it reports height lower than what was previously reported
+  ([ASA-2025-001](https://github.com/cometbft/cometbft/security/advisories/GHSA-22qq-3xwm-r5x4))
+- `[types]` Check that `Part.Index` equals `Part.Proof.Index`
+  ([ASA-2025-001](https://github.com/cometbft/cometbft/security/advisories/GHSA-r3r4-g7hq-pq4f))
+
+### DEPENDENCIES
+
+- `[go/runtime]` Bump minimum Go version to 1.22.11
+  ([\#4891](https://github.com/cometbft/cometbft/pull/4891))
+
+## v0.38.16
+
+*December 20 2024*
+
+This release:
+- fixes a bug that caused a node produce errors caused by the sending of next PEX requests too soon.
+As a consequence of this incorrect behavior a node would be marked as BAD.
+- Adds a proper description of `ExtendedVoteInfo` and `VoteInfo` in the spec.
+
+### BUG FIXES
+
+- `[mocks]` Mockery `v2.49.0` broke the mocks. We had to add a `.mockery.yaml` to
+properly handle this change.
+  ([\#4521](https://github.com/cometbft/cometbft/pull/4521))
+
+## v0.38.15
+
+*November 6, 2024*
+
+This release supersedes [`v0.38.14`](#v03814), which mistakenly updated the Go version to
+`1.23`, introducing an unintended breaking change. It sets the Go version back
+to `1.22.7` by reverting [\#4297](https://github.com/cometbft/cometbft/pull/4297).
+
+The release includes the bug fixes, performance improvements, and importantly,
+the fix for the security vulnerability in the vote extensions (VE) validation
+logic that were part of `v0.38.14`. For more details, please refer to [ASA-2024-011](https://github.com/cometbft/cometbft/security/advisories/GHSA-p7mv-53f2-4cwj).
+
+## v0.38.14
+
+*November 6, 2024*
+
+This release fixes a security vulnerability in the vote extensions (VE)
+validation logic. For more details, please refer to
+[ASA-2024-011](https://github.com/cometbft/cometbft/security/advisories/GHSA-p7mv-53f2-4cwj).
+
+We recommend upgrading ASAP if you’re using vote extensions (VE).
+
+### BUG FIXES
+
+- `[consensus]` Do not panic if the validator index of a `Vote` message is out
+  of bounds, when vote extensions are enabled
+  ([\#ABC-0021](https://github.com/cometbft/cometbft/security/advisories/GHSA-p7mv-53f2-4cwj))
+
+### DEPENDENCIES
+
+- Bump cometbft-db version to v0.15.0
+  ([\#4297](https://github.com/cometbft/cometbft/pull/4297))
+- `[go/runtime]` Bump Go version to 1.23
+  ([\#4297](https://github.com/cometbft/cometbft/pull/4297))
+
+### IMPROVEMENTS
+
+- `[p2p]` fix exponential backoff logic to increase reconnect retries close to 24 hours
+ ([\#3519](https://github.com/cometbft/cometbft/issues/3519))
+
+## v0.38.13
+
+*October 24, 2024*
+
+This patch release addresses the issue where tx_search was not returning all results, which only arises when upgrading
+to CometBFT-DB version 0.13 or later. It includes a fix in the state indexer to resolve this problem. We recommend
+upgrading to this patch release if you are affected by this issue.
+
+### BUG FIXES
+
+- `[metrics]` Call unused `rejected_txs` metric in mempool
+  ([\#4019](https://github.com/cometbft/cometbft/pull/4019))
+- `[state/indexer]` Fix the tx_search results not returning all results by changing the logic in the indexer to copy the key and values instead of reusing an iterator. This issue only arises when upgrading to cometbft-db v0.13 or later.
+  ([\#4295](https://github.com/cometbft/cometbft/issues/4295)). Special thanks to @faddat for reporting the issue.
+
+### DEPENDENCIES
+
+- `[go/runtime]` Bump Go version to 1.22
+  ([\#4073](https://github.com/cometbft/cometbft/pull/4073))
+- Bump cometbft-db version to v0.14.1
+  ([\#4321](https://github.com/cometbft/cometbft/pull/4321))
+
+### FEATURES
+
+- `[crypto]` use decred secp256k1 directly ([#4294](https://github.com/cometbft/cometbft/pull/4294))
+
+### IMPROVEMENTS
+
+- `[metrics]` Add `evicted_txs` metric to mempool
+  ([\#4019](https://github.com/cometbft/cometbft/pull/4019))
+- `[log]` Change "mempool is full" log to debug level
+  ([\#4123](https://github.com/cometbft/cometbft/pull/4123)) Special thanks to @yihuang.
+
+## v0.38.12
+
+*September 3, 2024*
+
+This release includes a security fix for the light client and is recommended
+for all users.
+
+### BUG FIXES
+
+- `[light]` Cross-check proposer priorities in retrieved validator sets
+  ([\#ASA-2024-009](https://github.com/cometbft/cometbft/security/advisories/GHSA-g5xx-c4hv-9ccc))
+- `[privval]` Ignore duplicate privval listen when already connected ([\#3828](https://github.com/cometbft/cometbft/issues/3828)
+
+### DEPENDENCIES
+
+- `[crypto/secp256k1]` Adjust to breaking interface changes in
+  `btcec/v2` latest release, while avoiding breaking changes to
+  local CometBFT functions
+  ([\#3728](https://github.com/cometbft/cometbft/pull/3728))
+- pinned mockery's version to v2.49.2 to prevent potential
+  changes in mocks after each new release of mockery
+  ([\#4605](https://github.com/cometbft/cometbft/pull/4605))
+
+### IMPROVEMENTS
+
+- `[types]` Check that proposer is one of the validators in `ValidateBasic`
+  ([\#ASA-2024-009](https://github.com/cometbft/cometbft/security/advisories/GHSA-g5xx-c4hv-9ccc))
+- `[e2e]` Add `log_level` option to manifest file
+  ([#3819](https://github.com/cometbft/cometbft/pull/3819)).
+- `[e2e]` Add `log_format` option to manifest file
+  ([#3836](https://github.com/cometbft/cometbft/issues/3836)).
+
+## v0.38.11
+
+*August 12, 2024*
+
+This release fixes a panic in consensus where CometBFT would previously panic
+if there's no extension signature in non-nil Precommit EVEN IF vote extensions
+themselves are disabled.
+
+It also includes a few other bug fixes and performance improvements.
+
+### BUG FIXES
+
+- `[types]` Only check IFF vote is a non-nil Precommit if extensionsEnabled
+  types ([\#3565](https://github.com/cometbft/cometbft/issues/3565))
+
+### IMPROVEMENTS
+
+- `[indexer]` Fixed ineffective select break statements; they now
+  point to their enclosing for loop label to exit
+  ([\#3544](https://github.com/cometbft/cometbft/issues/3544))
+
+## v0.38.10
+
+*July 16, 2024*
+
+This release fixes a bug in `v0.38.x` that prevented ABCI responses from being
+correctly read when upgrading from `v0.37.x` or below. It also includes a few other
+bug fixes and performance improvements.
+
+### BUG FIXES
+
+- `[p2p]` Node respects configured `max_num_outbound_peers` limit when dialing
+  peers provided by a seed node
+  ([\#486](https://github.com/cometbft/cometbft/issues/486))
+- `[rpc]` Fix an issue where a legacy ABCI response, created on `v0.37` or before, is not returned properly in `v0.38` and up
+  on the `/block_results` RPC endpoint.
+  ([\#3002](https://github.com/cometbft/cometbft/issues/3002))
+- `[blocksync]` Do not stay in blocksync if the node's validator voting power
+  is high enough to block the chain while it is not online
+  ([\#3406](https://github.com/cometbft/cometbft/pull/3406))
+
+### IMPROVEMENTS
+
+- `[p2p/conn]` Update send monitor, used for sending rate limiting, once per batch of packets sent
+  ([\#3382](https://github.com/cometbft/cometbft/pull/3382))
+- `[libs/pubsub]` Allow dash (`-`) in event tags
+  ([\#3401](https://github.com/cometbft/cometbft/issues/3401))
+- `[p2p/conn]` Remove the usage of a synchronous pool of buffers in secret connection, storing instead the buffer in the connection struct. This reduces the synchronization primitive usage, speeding up the code.
+  ([\#3403](https://github.com/cometbft/cometbft/issues/3403))
+
+## v0.38.9
+
+*July 1, 2024*
+
+This release reverts the API-breaking change to the Mempool interface introduced in the last patch
+release (v0.38.8) while still keeping the performance improvement added to the mempool. It also
+includes a minor fix to the RPC endpoints /tx and /tx_search.
+
+### BREAKING CHANGES
+
+- `[mempool]` Revert adding the method `PreUpdate()` to the `Mempool` interface, recently introduced
+  in the previous patch release (v0.38.8). Its logic is now moved into the `Lock` method. With this change,
+  the `Mempool` interface is the same as in v0.38.7.
+  ([\#3361](https://github.com/cometbft/cometbft/pull/3361))
+
+### BUG FIXES
+
+- `[rpc]` Fix nil pointer error in `/tx` and `/tx_search` when block is
+  absent ([\#3352](https://github.com/cometbft/cometbft/issues/3352))
+
+## v0.38.8
+
+*June 27, 2024*
+
+This release contains a few bug fixes and performance improvements.
+
+### BREAKING CHANGES
+
+- `[mempool]` Add to the `Mempool` interface a new method `PreUpdate()`. This method should be
+  called before acquiring the mempool lock, to signal that a new update is coming. Also add to
+  `ErrMempoolIsFull` a new field `RecheckFull`.
+  ([\#3314](https://github.com/cometbft/cometbft/pull/3314))
+
+### BUG FIXES
+
+- `[blockstore]` Added peer banning in blockstore
+  ([\#ABC-0013](https://github.com/cometbft/cometbft/security/advisories/GHSA-hg58-rf2h-6rr7))
+- `[blockstore]` Send correct error message when vote extensions do not align with received packet
+  ([\#ABC-0014](https://github.com/cometbft/cometbft/security/advisories/GHSA-hg58-rf2h-6rr7))
+- [`mempool`] Fix data race when rechecking with async ABCI client
+  ([\#1827](https://github.com/cometbft/cometbft/issues/1827))
+- `[consensus]` Fix a race condition in the consensus timeout ticker. Race is caused by two timeouts being scheduled at the same time.
+  ([\#3092](https://github.com/cometbft/cometbft/pull/2136))
+- `[types]` Do not batch verify a commit if the validator set keys have different
+  types. ([\#3195](https://github.com/cometbft/cometbft/issues/3195)
+
+### IMPROVEMENTS
+
+- `[config]` Added `recheck_timeout` mempool parameter to set how much time to wait for recheck
+  responses from the app (only applies to non-local ABCI clients).
+  ([\#1827](https://github.com/cometbft/cometbft/issues/1827/))
+- `[rpc]` Add a configurable maximum batch size for RPC requests.
+  ([\#2867](https://github.com/cometbft/cometbft/pull/2867)).
+- `[event-bus]` Remove the debug logs in PublishEventTx, which were noticed production slowdowns.
+  ([\#2911](https://github.com/cometbft/cometbft/pull/2911))
+- `[state/execution]` Cache the block hash computation inside of the Block Type, so we only compute it once.
+  ([\#2924](https://github.com/cometbft/cometbft/pull/2924))
+- `[consensus/state]` Remove a redundant `VerifyBlock` call in `FinalizeCommit`
+  ([\#2928](https://github.com/cometbft/cometbft/pull/2928))
+- `[p2p/channel]` Speedup `ProtoIO` writer creation time, and thereby speedup channel writing by 5%.
+  ([\#2949](https://github.com/cometbft/cometbft/pull/2949))
+- `[p2p/conn]` Minor speedup (3%) to connection.WritePacketMsgTo, by removing MinInt calls.
+  ([\#2952](https://github.com/cometbft/cometbft/pull/2952))
+- `[internal/bits]` 10x speedup creating initialized bitArrays, which speedsup extendedCommit.BitArray(). This is used in consensus vote gossip.
+  ([\#2959](https://github.com/cometbft/cometbft/pull/2841)).
+- `[blockstore]` Remove a redundant `Header.ValidateBasic` call in `LoadBlockMeta`, 75% reducing this time.
+  ([\#2964](https://github.com/cometbft/cometbft/pull/2964))
+- `[p2p/conn]` Speedup connection.WritePacketMsgTo, by reusing internal buffers rather than re-allocating.
+  ([\#2986](https://github.com/cometbft/cometbft/pull/2986))
+- [`blockstore`] Use LRU caches in blockstore, significiantly improving consensus gossip routine performance
+  ([\#3003](https://github.com/cometbft/cometbft/issues/3003)
+- [`consensus`] Improve performance of consensus metrics by lowering string operations
+  ([\#3017](https://github.com/cometbft/cometbft/issues/3017)
+- [`protoio`] Remove one allocation and new object call from `ReadMsg`,
+  leading to a 4% p2p message reading performance gain.
+  ([\#3018](https://github.com/cometbft/cometbft/issues/3018)
+- `[mempool]` Before updating the mempool, consider it as full if rechecking is still in progress.
+  This will stop accepting transactions in the mempool if the node can't keep up with re-CheckTx.
+  ([\#3314](https://github.com/cometbft/cometbft/pull/3314))
+
+## v0.38.7
+
+*April 26, 2024*
+
+This release contains a few bug fixes and performance improvements.
+
+### BUG FIXES
+
+- [`mempool`] Panic when a CheckTx request to the app returns an error
+  ([\#2225](https://github.com/cometbft/cometbft/pull/2225))
+- [`bits`] prevent `BitArray.UnmarshalJSON` from crashing on 0 bits
+  ([\#2774](https://github.com/cometbft/cometbft/pull/2774))
+
+### FEATURES
+
+- [`node`] Add `BootstrapStateWithGenProvider` to boostrap state using a custom
+  genesis doc provider ([\#2793](https://github.com/cometbft/cometbft/pull/2793))
+
+### IMPROVEMENTS
+
+- `[state/indexer]` Lower the heap allocation of transaction searches
+  ([\#2839](https://github.com/cometbft/cometbft/pull/2839))
+- `[internal/bits]` 10x speedup and remove heap overhead of bitArray.PickRandom (used extensively in consensus gossip)
+  ([\#2841](https://github.com/cometbft/cometbft/pull/2841)).
+- `[libs/json]` Lower the memory overhead of JSON encoding by using JSON encoders internally
+  ([\#2846](https://github.com/cometbft/cometbft/pull/2846)).
+
+## v0.38.6
+
+*March 12, 2024*
+
+This release fixes a security bug in the light client. It also introduces many
+improvements to the block sync in collaboration with the
+[Osmosis](https://osmosis.zone/) team.
+
+### BUG FIXES
+
+- `[privval]` Retry accepting a connection ([\#2047](https://github.com/cometbft/cometbft/pull/2047))
+- `[state]` Fix rollback to a specific height
+  ([\#2136](https://github.com/cometbft/cometbft/pull/2136))
+
+### FEATURES
+
+- `[e2e]` Add `block_max_bytes` option to the manifest file.
+  ([\#2362](https://github.com/cometbft/cometbft/pull/2362))
+
+### IMPROVEMENTS
+
+- `[blocksync]` Avoid double-calling `types.BlockFromProto` for performance
+  reasons ([\#2016](https://github.com/cometbft/cometbft/pull/2016))
+- `[e2e]` Add manifest option `load_max_txs` to limit the number of transactions generated by the
+  `load` command. ([\#2094](https://github.com/cometbft/cometbft/pull/2094))
+- `[jsonrpc]` enable HTTP basic auth in websocket client ([#2434](https://github.com/cometbft/cometbft/pull/2434))
+- `[blocksync]` make the max number of downloaded blocks dynamic.
+  Previously it was a const 600. Now it's `peersCount * maxPendingRequestsPerPeer (20)`
+  [\#2467](https://github.com/cometbft/cometbft/pull/2467)
+- `[blocksync]` Request a block from peer B if we are approaching pool's height
+  (less than 50 blocks) and the current peer A is slow in sending us the
+  block [\#2475](https://github.com/cometbft/cometbft/pull/2475)
+- `[blocksync]` Request the block N from peer B immediately after getting
+  `NoBlockResponse` from peer A
+  [\#2475](https://github.com/cometbft/cometbft/pull/2475)
+- `[blocksync]` Sort peers by download rate (the fastest peer is picked first)
+  [\#2475](https://github.com/cometbft/cometbft/pull/2475)
+
 ## v0.38.5
 
 *January 24, 2024*

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -595,4 +595,88 @@ func (br *ByzantineReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (br *ByzantineReactor) Receive(e p2p.Envelope) {
 	br.reactor.Receive(e)
 }
+
 func (br *ByzantineReactor) InitPeer(peer p2p.Peer) p2p.Peer { return peer }
+
+// Large/oversized proposals should be rejected
+func TestRejectOversizedProposals(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	n := 2
+	css, cleanup := randConsensusNet(t, n, "consensus_reactor_test", newMockTickerFunc(false), newKVStore)
+	defer cleanup()
+
+	switches := make([]*p2p.Switch, n)
+	p2pLogger := consensusLogger().With("module", "p2p")
+	for i := 0; i < n; i++ {
+		switches[i] = p2p.MakeSwitch(
+			config.P2P,
+			i,
+			func(_ int, sw *p2p.Switch) *p2p.Switch {
+				return sw
+			})
+		switches[i].SetLogger(p2pLogger.With("validator", i))
+	}
+
+	reactors := make([]p2p.Reactor, n)
+	for i := 0; i < n; i++ {
+		conR := NewReactor(css[i], false)
+		defer func() { require.NoError(t, conR.Stop()) }()
+
+		conR.SetLogger(consensusLogger().With("validator", i))
+		reactors[i] = conR
+	}
+
+	p2p.MakeConnectedSwitches(config.P2P, n, func(i int, _ *p2p.Switch) *p2p.Switch {
+		switches[i].AddReactor("CONSENSUS", reactors[i])
+		return switches[i]
+	}, p2p.Connect2Switches)
+
+	peers := switches[0].Peers().List()
+	targetPeer := peers[0]
+
+	height := int64(1)
+	round := int32(0)
+	cs := css[0]
+
+	block, err := cs.createProposalBlock(ctx)
+	require.NoError(t, err)
+
+	blockParts, err := block.MakePartSet(types.BlockPartSizeBytes)
+	require.NoError(t, err)
+
+	// create oversized proposal
+	propBlockID := types.BlockID{Hash: block.Hash(), PartSetHeader: blockParts.Header()}
+	propBlockID.PartSetHeader.Total = 4294967295
+
+	proposal := types.NewProposal(height, round, -1, propBlockID)
+	p := proposal.ToProto()
+	if err := cs.privValidator.SignProposal(cs.state.ChainID, p); err != nil {
+		t.Error(err)
+	}
+	proposal.Signature = p.Signature
+
+	success := targetPeer.Send(p2p.Envelope{
+		ChannelID: DataChannel,
+		Message:   &cmtcons.Proposal{Proposal: *proposal.ToProto()},
+	})
+	require.True(t, success)
+
+	select {
+	case e := <-css[1].peerMsgQueue:
+		// if we receive a message here, the peer incorrectly accepted the
+		// oversized proposal
+		if _, receivedProposal := e.Msg.(*ProposalMessage); receivedProposal {
+			assert.Fail(t, "peer incorrectly accepted oversized proposal")
+			return
+		}
+		// invalid state, we received some other unexpected message type, fail
+		// the test
+		assert.Fail(t, "received unexpected message type on peer msg queue, expected *ProposalMessage")
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		// timeout after 500ms if nothing has happened and assume peer rejected
+		// the proposal
+	}
+}

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1610,6 +1610,9 @@ func (m *NewValidBlockMessage) ValidateBasic() error {
 	if err := m.BlockPartSetHeader.ValidateBasic(); err != nil {
 		return fmt.Errorf("wrong BlockPartSetHeader: %v", err)
 	}
+	if err := m.BlockParts.ValidateBasic(); err != nil {
+		return fmt.Errorf("validating BlockParts: %w", err)
+	}
 	if m.BlockParts.Size() == 0 {
 		return errors.New("empty blockParts")
 	}
@@ -1669,6 +1672,9 @@ func (m *ProposalPOLMessage) ValidateBasic() error {
 	}
 	if m.ProposalPOLRound < 0 {
 		return errors.New("negative ProposalPOLRound")
+	}
+	if err := m.ProposalPOL.ValidateBasic(); err != nil {
+		return fmt.Errorf("validating ProposalPOL: %w", err)
 	}
 	if m.ProposalPOL.Size() == 0 {
 		return errors.New("empty ProposalPOL bit array")
@@ -1814,6 +1820,9 @@ func (m *VoteSetBitsMessage) ValidateBasic() error {
 	}
 	if err := m.BlockID.ValidateBasic(); err != nil {
 		return fmt.Errorf("wrong BlockID: %v", err)
+	}
+	if err := m.Votes.ValidateBasic(); err != nil {
+		return fmt.Errorf("validating Votes: %w", err)
 	}
 	// NOTE: Votes.Size() can be zero if the node does not have any
 	if m.Votes.Size() > types.MaxVotesCount {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -320,6 +320,15 @@ func (conR *Reactor) Receive(e p2p.Envelope) {
 		}
 		switch msg := msg.(type) {
 		case *ProposalMessage:
+			conR.conS.mtx.RLock()
+			maxBytes := conR.conS.state.ConsensusParams.Block.MaxBytes
+			conR.conS.mtx.RUnlock()
+			if err := msg.Proposal.ValidateBlockSize(maxBytes); err != nil {
+				conR.Logger.Error("Rejecting oversized proposal", "peer", e.Src, "height", msg.Proposal.Height)
+				conR.Switch.StopPeerForError(e.Src, ErrProposalTooManyParts)
+				return
+			}
+
 			ps.SetHasProposal(msg.Proposal)
 			conR.conS.peerMsgQueue <- msgInfo{msg, e.Src.ID()}
 		case *ProposalPOLMessage:
@@ -1631,6 +1640,12 @@ type ProposalMessage struct {
 // ValidateBasic performs basic validation.
 func (m *ProposalMessage) ValidateBasic() error {
 	return m.Proposal.ValidateBasic()
+}
+
+// ValidateBlockSize validates the proposals block size against a maximum. If
+// -1 is passed, types.MaxBlockSizeBytes will be used as the maximum.
+func (m *ProposalMessage) ValidateBlockSize(maxBlockSizeBytes int64) error {
+	return m.Proposal.ValidateBlockSize(maxBlockSizeBytes)
 }
 
 // String returns a string representation.

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -888,6 +888,14 @@ func TestNewValidBlockMessageValidateBasic(t *testing.T) {
 			func(msg *NewValidBlockMessage) { msg.BlockParts = bits.NewBitArray(int(types.MaxBlockPartsCount) + 1) },
 			"blockParts bit array size 1602 not equal to BlockPartSetHeader.Total 1",
 		},
+		{
+			func(msg *NewValidBlockMessage) { msg.BlockParts.Elems = nil },
+			"mismatch between specified number of bits 1, and number of elements 0, expected 1 elements",
+		},
+		{
+			func(msg *NewValidBlockMessage) { msg.BlockParts.Bits = 500 },
+			"mismatch between specified number of bits 500, and number of elements 1, expected 8 elements",
+		},
 	}
 
 	for i, tc := range testCases {
@@ -923,6 +931,14 @@ func TestProposalPOLMessageValidateBasic(t *testing.T) {
 		{
 			func(msg *ProposalPOLMessage) { msg.ProposalPOL = bits.NewBitArray(types.MaxVotesCount + 1) },
 			"proposalPOL bit array is too big: 10001, max: 10000",
+		},
+		{
+			func(msg *ProposalPOLMessage) { msg.ProposalPOL.Elems = nil },
+			"mismatch between specified number of bits 1, and number of elements 0, expected 1 elements",
+		},
+		{
+			func(msg *ProposalPOLMessage) { msg.ProposalPOL.Bits = 500 },
+			"mismatch between specified number of bits 500, and number of elements 1, expected 8 elements",
 		},
 	}
 
@@ -1079,6 +1095,14 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 		{
 			func(msg *VoteSetBitsMessage) { msg.Votes = bits.NewBitArray(types.MaxVotesCount + 1) },
 			"votes bit array is too big: 10001, max: 10000",
+		},
+		{
+			func(msg *VoteSetBitsMessage) { msg.Votes.Elems = nil },
+			"mismatch between specified number of bits 1, and number of elements 0, expected 1 elements",
+		},
+		{
+			func(msg *VoteSetBitsMessage) { msg.Votes.Bits = 500 },
+			"mismatch between specified number of bits 500, and number of elements 1, expected 8 elements",
 		},
 	}
 

--- a/libs/bits/bit_array.go
+++ b/libs/bits/bit_array.go
@@ -409,6 +409,13 @@ func (bA *BitArray) UnmarshalJSON(bz []byte) error {
 	// Construct new BitArray and copy over.
 	numBits := len(bits)
 	bA2 := NewBitArray(numBits)
+	if bA2 == nil {
+		// Treat it as if we encountered the case: b == "null"
+		bA.Bits = 0
+		bA.Elems = nil
+		return nil
+	}
+
 	for i := 0; i < numBits; i++ {
 		if bits[i] == 'x' {
 			bA2.SetIndex(i, true)

--- a/libs/bits/bit_array.go
+++ b/libs/bits/bit_array.go
@@ -3,6 +3,7 @@ package bits
 import (
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 	"regexp"
 	"strings"
 	"sync"
@@ -27,11 +28,31 @@ func NewBitArray(bits int) *BitArray {
 	}
 	return &BitArray{
 		Bits:  bits,
-		Elems: make([]uint64, (bits+63)/64),
+		Elems: make([]uint64, numElements(bits)),
 	}
 }
 
-// Size returns the number of bits in the bitarray
+// NewBitArrayFromFn returns a new bit array.
+// It returns nil if the number of bits is zero.
+// It initializes the `i`th bit to the value of `fn(i)`.
+func NewBitArrayFromFn(bits int, fn func(int) bool) *BitArray {
+	if bits <= 0 {
+		return nil
+	}
+	bA := &BitArray{
+		Bits:  bits,
+		Elems: make([]uint64, numElements(bits)),
+	}
+	for i := 0; i < bits; i++ {
+		v := fn(i)
+		if v {
+			bA.Elems[i/64] |= (uint64(1) << uint(i%64))
+		}
+	}
+	return bA
+}
+
+// Size returns the number of bits in the bitarray.
 func (bA *BitArray) Size() int {
 	if bA == nil {
 		return 0
@@ -69,7 +90,7 @@ func (bA *BitArray) SetIndex(i int, v bool) bool {
 }
 
 func (bA *BitArray) setIndex(i int, v bool) bool {
-	if i >= bA.Bits {
+	if i >= bA.Bits || i/64 >= len(bA.Elems) {
 		return false
 	}
 	if v {
@@ -100,7 +121,7 @@ func (bA *BitArray) copy() *BitArray {
 }
 
 func (bA *BitArray) copyBits(bits int) *BitArray {
-	c := make([]uint64, (bits+63)/64)
+	c := make([]uint64, numElements(bits))
 	copy(c, bA.Elems)
 	return &BitArray{
 		Bits:  bits,
@@ -247,44 +268,74 @@ func (bA *BitArray) PickRandom() (int, bool) {
 	}
 
 	bA.mtx.Lock()
-	trueIndices := bA.getTrueIndices()
-	bA.mtx.Unlock()
-
-	if len(trueIndices) == 0 { // no bits set to true
+	numTrueIndices := bA.getNumTrueIndices()
+	if numTrueIndices == 0 { // no bits set to true
+		bA.mtx.Unlock()
 		return 0, false
 	}
-
-	return trueIndices[cmtrand.Intn(len(trueIndices))], true
+	index := bA.getNthTrueIndex(cmtrand.Intn(numTrueIndices))
+	bA.mtx.Unlock()
+	if index == -1 {
+		return 0, false
+	}
+	return index, true
 }
 
-func (bA *BitArray) getTrueIndices() []int {
-	trueIndices := make([]int, 0, bA.Bits)
-	curBit := 0
+func (bA *BitArray) getNumTrueIndices() int {
+	if bA.Size() == 0 || len(bA.Elems) == 0 || len(bA.Elems) != numElements(bA.Size()) {
+		// size and elements must be valid to do this calc
+		return 0
+	}
+
+	count := 0
 	numElems := len(bA.Elems)
-	// set all true indices
+	// handle all elements except the last one
 	for i := 0; i < numElems-1; i++ {
-		elem := bA.Elems[i]
-		if elem == 0 {
-			curBit += 64
-			continue
-		}
-		for j := 0; j < 64; j++ {
-			if (elem & (uint64(1) << uint64(j))) > 0 {
-				trueIndices = append(trueIndices, curBit)
-			}
-			curBit++
-		}
+		count += bits.OnesCount64(bA.Elems[i])
 	}
 	// handle last element
-	lastElem := bA.Elems[numElems-1]
-	numFinalBits := bA.Bits - curBit
+	numFinalBits := bA.Bits - (numElems-1)*64
 	for i := 0; i < numFinalBits; i++ {
-		if (lastElem & (uint64(1) << uint64(i))) > 0 {
-			trueIndices = append(trueIndices, curBit)
+		if (bA.Elems[numElems-1] & (uint64(1) << uint64(i))) > 0 {
+			count++
 		}
-		curBit++
 	}
-	return trueIndices
+	return count
+}
+
+// getNthTrueIndex returns the index of the nth true bit in the bit array.
+// n is 0 indexed. (e.g. for bitarray x__x, getNthTrueIndex(0) returns 0).
+// If there is no such value, it returns -1.
+func (bA *BitArray) getNthTrueIndex(n int) int {
+	numElems := len(bA.Elems)
+	count := 0
+
+	// Iterate over each element
+	for i := 0; i < numElems; i++ {
+		// Count set bits in the current element
+		setBits := bits.OnesCount64(bA.Elems[i])
+
+		// If the count of set bits in this element plus the count so far
+		// is greater than or equal to n, then the nth bit must be in this element
+		if count+setBits >= n {
+			// Find the index of the nth set bit within this element
+			for j := 0; j < 64; j++ {
+				if bA.Elems[i]&(1<<uint(j)) != 0 {
+					if count == n {
+						// Calculate the absolute index of the set bit
+						return i*64 + j
+					}
+					count++
+				}
+			}
+		} else {
+			// If the count is not enough, continue to the next element
+			count += setBits
+		}
+	}
+
+	// If we reach here, it means n is out of range
+	return -1
 }
 
 // String returns a string representation of BitArray: BA{<bit-string>},
@@ -448,4 +499,23 @@ func (bA *BitArray) FromProto(protoBitArray *cmtprotobits.BitArray) {
 	if len(protoBitArray.Elems) > 0 {
 		bA.Elems = protoBitArray.Elems
 	}
+}
+
+// ValidateBasic validates a BitArray. Note that a nil BitArray and BitArray of
+// size 0 bits is valid. However the number of Bits and Elems be valid based on
+// each other.
+func (bA *BitArray) ValidateBasic() error {
+	if bA == nil {
+		return nil
+	}
+
+	expectedElems := numElements(bA.Size())
+	if expectedElems != len(bA.Elems) {
+		return fmt.Errorf("mismatch between specified number of bits %d, and number of elements %d, expected %d elements", bA.Size(), len(bA.Elems), expectedElems)
+	}
+	return nil
+}
+
+func numElements(bits int) int {
+	return (bits + 63) / 64
 }

--- a/libs/bits/bit_array_test.go
+++ b/libs/bits/bit_array_test.go
@@ -141,7 +141,111 @@ func TestPickRandom(t *testing.T) {
 	}
 }
 
-func TestBytes(_ *testing.T) {
+func TestGetNumTrueIndices(t *testing.T) {
+	type testcase struct {
+		Input          string
+		ExpectedResult int
+	}
+	testCases := []testcase{
+		{"x_x_x_", 3},
+		{"______", 0},
+		{"xxxxxx", 6},
+		{"x_x_x_x_x_x_x_x_x_", 9},
+	}
+	numOriginalTestCases := len(testCases)
+	for i := 0; i < numOriginalTestCases; i++ {
+		testCases = append(testCases, testcase{testCases[i].Input + "x", testCases[i].ExpectedResult + 1})
+		testCases = append(testCases, testcase{full64bits + testCases[i].Input, testCases[i].ExpectedResult + 64})
+		testCases = append(testCases, testcase{empty64Bits + testCases[i].Input, testCases[i].ExpectedResult})
+	}
+
+	for _, tc := range testCases {
+		var bitArr *BitArray
+		err := json.Unmarshal([]byte(`"`+tc.Input+`"`), &bitArr)
+		require.NoError(t, err)
+		result := bitArr.getNumTrueIndices()
+		require.Equal(t, tc.ExpectedResult, result, "for input %s, expected %d, got %d", tc.Input, tc.ExpectedResult, result)
+		result = bitArr.Not().getNumTrueIndices()
+		require.Equal(t, bitArr.Bits-result, bitArr.getNumTrueIndices())
+	}
+}
+
+func TestGetNumTrueIndicesInvalidStates(t *testing.T) {
+	testCases := []struct {
+		name string
+		bA1  *BitArray
+		exp  int
+	}{
+		{"empty", &BitArray{}, 0},
+		{"explicit 0 bits nil elements", &BitArray{Bits: 0, Elems: nil}, 0},
+		{"explicit 0 bits 0 len elements", &BitArray{Bits: 0, Elems: make([]uint64, 0)}, 0},
+		{"nil", nil, 0},
+		{"with elements", NewBitArray(10), 0},
+		{"more elements than bits specifies", &BitArray{Bits: 0, Elems: make([]uint64, 5)}, 0},
+		{"less elements than bits specifies", &BitArray{Bits: 200, Elems: make([]uint64, 1)}, 0},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := tc.bA1.getNumTrueIndices()
+			require.Equal(t, n, tc.exp)
+		})
+	}
+}
+
+func TestGetNthTrueIndex(t *testing.T) {
+	type testcase struct {
+		Input          string
+		N              int
+		ExpectedResult int
+	}
+	testCases := []testcase{
+		// Basic cases
+		{"x_x_x_", 0, 0},
+		{"x_x_x_", 1, 2},
+		{"x_x_x_", 2, 4},
+		{"______", 1, -1},         // No true indices
+		{"xxxxxx", 5, 5},          // Last true index
+		{"x_x_x_x_x_x_x_", 9, -1}, // Out-of-range
+
+		// Edge cases
+		{"xxxxxx", 7, -1}, // Out-of-range
+		{"______", 0, -1}, // No true indices
+		{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 49, 49},  // Last true index
+		{"____________________________________________", 1, -1},                               // No true indices
+		{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 63, 63},  // last index of first word
+		{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 64, 64},  // first index of second word
+		{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 100, -1}, // Out-of-range
+
+		// Input beyond 64 bits
+		{"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", 99, 99}, // Last true index
+
+		// Input less than 64 bits
+		{"x_x_x_", 3, -1}, // Out-of-range
+	}
+
+	numOriginalTestCases := len(testCases)
+	// Add 64 underscores to each test case
+	for i := 0; i < numOriginalTestCases; i++ {
+		expectedResult := testCases[i].ExpectedResult
+		if expectedResult != -1 {
+			expectedResult += 64
+		}
+		testCases = append(testCases, testcase{empty64Bits + testCases[i].Input, testCases[i].N, expectedResult})
+	}
+
+	for _, tc := range testCases {
+		var bitArr *BitArray
+		err := json.Unmarshal([]byte(`"`+tc.Input+`"`), &bitArr)
+		require.NoError(t, err)
+
+		// Get the nth true index
+		result := bitArr.getNthTrueIndex(tc.N)
+
+		require.Equal(t, tc.ExpectedResult, result, "for bit array %s, input %d,  expected %d, got %d", tc.Input, tc.N, tc.ExpectedResult, result)
+	}
+}
+
+func TestBytes(t *testing.T) {
 	bA := NewBitArray(4)
 	bA.SetIndex(0, true)
 	check := func(bA *BitArray, bz []byte) {
@@ -168,6 +272,10 @@ func TestBytes(_ *testing.T) {
 	check(bA, []byte{0x80, 0x01})
 	bA.SetIndex(9, true)
 	check(bA, []byte{0x80, 0x03})
+
+	bA = NewBitArray(4)
+	bA.Elems = nil
+	require.False(t, bA.SetIndex(1, true))
 }
 
 func TestEmptyFull(t *testing.T) {
@@ -283,5 +391,54 @@ func TestBitArrayProtoBuf(t *testing.T) {
 		} else {
 			require.NotEqual(t, tc.bA1, ba, tc.msg)
 		}
+	}
+}
+
+func TestBitArrayValidateBasic(t *testing.T) {
+	testCases := []struct {
+		name    string
+		bA1     *BitArray
+		expPass bool
+	}{
+		{"valid empty", &BitArray{}, true},
+		{"valid explicit 0 bits nil elements", &BitArray{Bits: 0, Elems: nil}, true},
+		{"valid explicit 0 bits 0 len elements", &BitArray{Bits: 0, Elems: make([]uint64, 0)}, true},
+		{"valid nil", nil, true},
+		{"valid with elements", NewBitArray(10), true},
+		{"more elements than bits specifies", &BitArray{Bits: 0, Elems: make([]uint64, 5)}, false},
+		{"less elements than bits specifies", &BitArray{Bits: 200, Elems: make([]uint64, 1)}, false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.bA1.ValidateBasic()
+			require.Equal(t, err == nil, tc.expPass)
+		})
+	}
+}
+
+// Tests that UnmarshalJSON doesn't crash when no bits are passed into the JSON.
+// See issue https://github.com/cometbft/cometbft/issues/2658
+func TestUnmarshalJSONDoesntCrashOnZeroBits(t *testing.T) {
+	type indexCorpus struct {
+		BitArray *BitArray `json:"ba"`
+		Index    int       `json:"i"`
+	}
+
+	ic := new(indexCorpus)
+	blob := []byte(`{"BA":""}`)
+	err := json.Unmarshal(blob, ic)
+	require.NoError(t, err)
+	require.Equal(t, ic.BitArray, &BitArray{Bits: 0, Elems: nil})
+}
+
+func BenchmarkPickRandomBitArray(b *testing.B) {
+	// A random 150 bit string to use as the benchmark bit array
+	benchmarkBitArrayStr := "_______xx__xxx_xx__x_xx_x_x_x__x_x_x_xx__xx__xxx__xx_x_xxx_x__xx____x____xx__xx____x_x__x_____xx_xx_xxxxxxx__xx_x_xxxx_x___x_xxxxx_xx__xxxx_xx_x___x_x"
+	var bitArr *BitArray
+	err := json.Unmarshal([]byte(`"`+benchmarkBitArrayStr+`"`), &bitArr)
+	require.NoError(b, err)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = bitArr.PickRandom()
 	}
 }

--- a/libs/bits/bit_array_test.go
+++ b/libs/bits/bit_array_test.go
@@ -12,6 +12,13 @@ import (
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 )
 
+var (
+	empty16Bits = "________________"
+	empty64Bits = empty16Bits + empty16Bits + empty16Bits + empty16Bits
+	full16bits  = "xxxxxxxxxxxxxxxx"
+	full64bits  = full16bits + full16bits + full16bits + full16bits
+)
+
 func randBitArray(bits int) (*BitArray, []byte) {
 	src := cmtrand.Bytes((bits + 7) / 8)
 	bA := NewBitArray(bits)

--- a/types/proposal.go
+++ b/types/proposal.go
@@ -79,6 +79,22 @@ func (p *Proposal) ValidateBasic() error {
 	return nil
 }
 
+// ValidateBlockSize block size ensures that a proposal block is not larger
+// than a maximum number of bytes, based on the total amount of parts reported
+// in the PartSetHeader. If -1 is passed as the maxBlockSizeBytes,
+// types.MaxBlockSizeBytes will be used as the maximum.
+func (p *Proposal) ValidateBlockSize(maxBlockSizeBytes int64) error {
+	if maxBlockSizeBytes == -1 {
+		maxBlockSizeBytes = int64(MaxBlockSizeBytes)
+	}
+	totalParts := int64(p.BlockID.PartSetHeader.Total)
+	maxParts := (maxBlockSizeBytes-1)/int64(BlockPartSizeBytes) + 1
+	if totalParts > maxParts {
+		return fmt.Errorf("proposal has too many parts %d (max: %d)", totalParts, maxParts)
+	}
+	return nil
+}
+
 // String returns a string representation of the Proposal.
 //
 // 1. height

--- a/types/proposal_test.go
+++ b/types/proposal_test.go
@@ -190,3 +190,30 @@ func TestProposalProtoBuf(t *testing.T) {
 		}
 	}
 }
+
+func TestProposalValidateBlockSize(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		maxBlockSize int64
+		proposal     *Proposal
+		expectPass   bool
+	}{
+		{"10 chunk max, 5 chunk proposal, success", int64(10 * BlockPartSizeBytes), NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: 5}}), true},
+		{"10 chunk max, 20 chunk proposal, fail", int64(10 * BlockPartSizeBytes), NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: 20}}), false},
+		{"10 chunk max, max uint32 chunk proposal, fail", int64(10 * BlockPartSizeBytes), NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: math.MaxUint32}}), false},
+		{"-1 chunk max, max uint32 chunk proposal, fail", -1, NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: math.MaxUint32}}), false},
+		{"0 chunk max, max uint32 chunk proposal, fail", -1, NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: math.MaxUint32}}), false},
+		{"total parts equals chunk max, success", -1, NewProposal(0, 0, 0, BlockID{PartSetHeader: PartSetHeader{Total: 1600}}), true},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.testName, func(t *testing.T) {
+			err := tc.proposal.ValidateBlockSize(tc.maxBlockSize)
+			if tc.expectPass {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backpor commit https://github.com/dydxprotocol/cometbft/pull/52/commits/5ba75e6208b8d8c91a996f4210fe0110d6002f50 as part of security advisory https://github.com/cometbft/cometbft/security/advisories/GHSA-hrhf-2vcr-ghch
- the other commits in this PR are necessary for https://github.com/dydxprotocol/cometbft/pull/52/commits/5ba75e6208b8d8c91a996f4210fe0110d6002f50 to build / test successfully while fixing other medium severity bugs
---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

