### PR TITLE
fix: Rechecktx idling when mempool is empty

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -706,10 +706,6 @@ func (mem *CListMempool) purgeExpiredTxs(blockHeight int64, blockTime time.Time)
 func (mem *CListMempool) recheckTxs() {
 	mem.logger.Debug("recheck txs", "height", mem.height.Load(), "num-txs", mem.Size())
 
-	if mem.Size() <= 0 {
-		return
-	}
-
 	for e := mem.txs.Front(); e != nil; e = e.Next() {
 		memTx := e.Value.(*mempoolTx)
 		// If this transaction is Cosmos transaction containing a
@@ -721,6 +717,14 @@ func (mem *CListMempool) recheckTxs() {
 			}
 		}
 	}
+
+	// If the mempool is empty after removing short-term CLOB transactions, there will be no
+	// recheck responses sent by the app, so waiting on mem.recheck.doneRechecking() would
+	// block until mem.config.RecheckTimeout elapses. Early-return here avoids that idle wait.
+	if mem.Size() <= 0 {
+		return
+	}
+
 	mem.recheck.init(mem.txs.Front(), mem.txs.Back())
 
 	// NOTE: globalCb may be called concurrently, but CheckTx cannot be executed concurrently


### PR DESCRIPTION
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

Fixed a bug where, when a block had only  Short Term Clob Order Transactions these would be remove form the mempool but `recheckTxs` would try to recheck an empty mempool, but still wait for the channel signal that all the transactions are processed. This would cause the node to idle until the `recheck_timeout` duration was over. Over time, this would cause the node to fall behind consensus consistently for sometimes hours at a time. The small changes in this PR implement a check after the Short Term Clob Order Transactions to verify if there are still other transactions in the mempool to run RecheckTx on. 
